### PR TITLE
fix(dashboard): MCP ingestion 422 errors — wrong parameter name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ curl https://perception-mcp-w53xszfqnq-uc.a.run.app/health
 
 curl -X POST https://perception-mcp-w53xszfqnq-uc.a.run.app/mcp/tools/fetch_rss_feed \
   -H "Content-Type: application/json" \
-  -d '{"feed_id": "hackernews"}'
+  -d '{"feed_url": "https://news.ycombinator.com/rss", "max_items": 10}'
 ```
 
 ## Project Structure

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -45,7 +45,7 @@ export default function Dashboard() {
       const response = await fetch(`${MCP_URL}/mcp/tools/fetch_rss_feed`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ feed_id: 'hackernews' })
+        body: JSON.stringify({ feed_url: 'https://news.ycombinator.com/rss', time_window_hours: 24, max_items: 50 })
       })
 
       if (response.ok) {


### PR DESCRIPTION
## Summary

- Dashboard "Run Ingestion" button was sending `{"feed_id": "hackernews"}` to the MCP service
- MCP `FetchRSSFeedRequest` schema requires `feed_url` (a real URL), not `feed_id`
- Pydantic validation rejected every request with a 422 Unprocessable Entity error
- Also fixed the curl example in CLAUDE.md that had the same wrong parameter

**Root cause:** Parameter mismatch introduced in commit 1911c70

## Test plan

- [ ] Click "Run Ingestion" on dashboard — should succeed and show article count
- [ ] Verify no 422 errors in Cloud Run logs
- [ ] Verify curl example in CLAUDE.md works: `curl -X POST .../mcp/tools/fetch_rss_feed -H "Content-Type: application/json" -d '{"feed_url": "https://news.ycombinator.com/rss", "max_items": 10}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RSS feed ingestion configuration to use direct URLs instead of feed identifiers, and added configurable parameters for maximum items and time window settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->