### PR TITLE
fix: sort feed by newest, remove relevance scoring

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,20 +5,6 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
-          "fieldPath": "relevance_score",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "published_at",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "articles",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
           "fieldPath": "category",
           "order": "ASCENDING"
         },
@@ -41,8 +27,7 @@
           "order": "DESCENDING"
         }
       ]
-    }
-    ,
+    },
     {
       "collectionGroup": "ingestion_runs",
       "queryScope": "COLLECTION",

--- a/tests/firebase/test_dashboard_queries.py
+++ b/tests/firebase/test_dashboard_queries.py
@@ -201,13 +201,12 @@ class TestDashboardQueries:
                 )
             raise
 
-    def test_articles_by_relevance_query(self, firestore_db, skip_without_gcp_auth):
+    def test_articles_by_newest_query(self, firestore_db, skip_without_gcp_auth):
         """
-        Articles sorted by relevance (used in recommendations).
+        Articles sorted by newest first (primary feed ordering).
 
         Query:
             collection('articles')
-            .orderBy('relevance_score', 'desc')
             .orderBy('published_at', 'desc')
             .limit(20)
         """
@@ -215,7 +214,6 @@ class TestDashboardQueries:
 
         query = (
             firestore_db.collection("articles")
-            .order_by("relevance_score", direction=Query.DESCENDING)
             .order_by("published_at", direction=Query.DESCENDING)
             .limit(20)
         )
@@ -225,8 +223,8 @@ class TestDashboardQueries:
         except Exception as e:
             if "index" in str(e).lower():
                 pytest.fail(
-                    f"Articles relevance query missing index: {e}\n"
-                    "Add composite index: articles(relevance_score DESC, published_at DESC)"
+                    f"Articles newest query missing index: {e}\n"
+                    "Single-field orderBy shouldn't need composite index"
                 )
             elif "permission" in str(e).lower():
                 pytest.fail(f"Articles query permission denied: {e}")


### PR DESCRIPTION
## Summary

- **Feed now sorts by `published_at DESC`** instead of `relevance_score DESC, published_at DESC` — most articles have null relevance scores (Agent 3 not run during ingestion), causing unpredictable ordering
- **Removed Trending section**, score legend, and relevance badge from article cards — replaced with time-ago badge
- **Removed stale Firestore composite index** (`articles: relevance_score DESC, published_at DESC`)
- **Added `ingestion-complete` event listener** so feed auto-refreshes after ingestion finishes
- `relevance_score` kept in Firestore and agent tools (no backend changes)

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `firestore.indexes.json` valid JSON, stale index removed
- [x] `test_dashboard_queries.py` updated and syntax-valid
- [ ] Manual: confirm articles sorted newest-first on dashboard
- [ ] Manual: confirm no Trending section or relevance badges
- [ ] Deploy indexes: `firebase deploy --only firestore:indexes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed trending score feature from article display.
  * Articles now show time-ago indicators for publication date instead of trending metrics.
  * Changed article ordering to prioritize newest content first.
  * Simplified dashboard interface for a cleaner, more focused user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->