### PR TITLE
feat: dashboard landing, auto-ingestion, stale article fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Use `bd` for ALL tasks/issues (no markdown TODO lists).
 
 ## Project Overview
 
-**Perception** is an AI news intelligence platform using Google's Agent Development Kit (ADK). 8 specialized agents on Vertex AI Agent Engine coordinate to collect, analyze, and synthesize news into executive briefs.
+**Perception** is an AI news intelligence platform using Google's Agent Development Kit (ADK). 9 specialized agents on Vertex AI Agent Engine coordinate to collect, analyze, and synthesize news into executive briefs.
 
 **GCP Project:** `perception-with-intent`
 **Dashboard:** https://perception-with-intent.web.app
@@ -25,87 +25,118 @@ Use `bd` for ALL tasks/issues (no markdown TODO lists).
 ## Architecture
 
 ```
-Firebase Dashboard (React)
+Firebase Dashboard (React + Vite + TypeScript)
+    ↓ Firestore real-time listeners + auto-ingestion trigger
+Vertex AI Agent Engine (9 Agents via A2A Protocol)
+    ↓ ADK sub_agents + config_path references
+Cloud Run MCP Service (FastAPI, 7 tool endpoints + /trigger/ingestion)
     ↓
-Vertex AI Agent Engine (8 Agents via A2A Protocol)
-    ↓
-Cloud Run MCP Service (7 tool endpoints)
-    ↓
-Firestore (articles, daily_summaries, topics_to_monitor)
+Firestore (named database: "perception-db")
+  └── Collections: articles, daily_summaries, topics_to_monitor
 ```
 
 **Key principle:** Firebase = humans, Agents = thinking, MCPs = doing, Firestore = storage.
 
+### Two Entrypoints
+
+The agent system has two different entrypoints:
+
+1. **Local dev** (`perception_app/main.py`) - Imports `jvp_agent.build_a2a_agent()` and runs via uvicorn. The `jvp_agent` package is a **top-level module** (not inside `perception_app/`), providing the A2A protocol wrapper.
+
+2. **Production** (`perception_app/agent_engine_app.py`) - Loads the orchestrator YAML config for Vertex AI Agent Engine deployment. Currently stubbed with TODOs for ADK loader integration.
+
 ### Agent System (perception_app/perception_agent/agents/)
 
-| Agent | YAML Config | Role |
-|-------|-------------|------|
-| 0 | `agent_0_orchestrator.yaml` | Editor-in-Chief, coordinates workflow |
-| 1 | `agent_1_source_harvester.yaml` | Fetches news from RSS/APIs |
-| 2 | `agent_2_topic_manager.yaml` | Manages tracked keywords |
-| 3 | `agent_3_relevance_ranking.yaml` | Scores articles 1-10 |
-| 4 | `agent_4_brief_writer.yaml` | Generates summaries |
-| 5 | `agent_5_alert_anomaly.yaml` | Detects alerts |
-| 6 | `agent_6_validator.yaml` | Data quality checks |
-| 7 | `agent_7_storage_manager.yaml` | Firestore persistence |
-| 8 | `agent_8_tech_editor.yaml` | Technology section editor |
+Agent 0 (orchestrator) loads all sub-agents via `config_path` references in its YAML. Each agent has a corresponding tools file (`perception_app/perception_agent/tools/agent_N_tools.py`).
+
+| Agent | Role |
+|-------|------|
+| 0 - Orchestrator | Editor-in-Chief, coordinates the full ingestion workflow |
+| 1 - Source Harvester | Fetches news from RSS/APIs |
+| 2 - Topic Manager | Manages tracked keywords |
+| 3 - Relevance Ranking | Scores articles 1-10 |
+| 4 - Brief Writer | Generates executive summaries |
+| 5 - Alert & Anomaly | Detects alerts worth surfacing |
+| 6 - Validator | Data quality checks |
+| 7 - Storage Manager | Firestore persistence |
+| 8 - Tech Editor | Technology section curation |
 
 ### MCP Service (perception_app/mcp_service/)
 
-FastAPI endpoints at `/mcp/tools/*`:
-- `fetch_rss_feed` - RSS fetching (real implementation)
-- `fetch_api_feed`, `fetch_webpage` - Content fetching (stubbed)
-- `store_articles`, `generate_brief` - Storage/synthesis (stubbed)
-- `log_ingestion_run`, `send_notification` - Ops (stubbed)
+FastAPI app with routers at `/mcp/tools/*`. Real implementation: `fetch_rss_feed`. Stubbed: `fetch_api_feed`, `fetch_webpage`, `store_articles`, `generate_brief`, `log_ingestion_run`, `send_notification`. Also exposes `/trigger/ingestion` for dashboard auto-ingestion.
+
+### Dashboard (dashboard/)
+
+React 18 SPA with Firebase Auth (protected routes), Firestore real-time data, and an auto-ingestion hook (`useAutoIngestion`) that fires once per session on Dashboard mount. Uses shadcn/ui components (`dashboard/src/components/ui/`), Framer Motion animations, and Tremor charts.
+
+Routes: `/` (Articles feed), `/dashboard` (command center), `/briefs`, `/authors`, `/topics`, `/about` (landing), `/login`.
+
+**Firestore named database:** The dashboard connects to `perception-db` (not the default database): `getFirestore(app, 'perception-db')`.
+
+### Functions (functions/)
+
+Firebase Cloud Functions (Node.js 22). Minimal setup — `firebase-admin` + `firebase-functions` only. No TypeScript source files yet.
 
 ## Commands
 
 ### Setup
 ```bash
-make install                    # Create venv and install deps
+make install                    # Create venv + install requirements.txt
+pip install -r requirements-test.txt  # Additional test deps (separate file)
 gcloud auth application-default login
 gcloud config set project perception-with-intent
 ```
 
 ### Development
 ```bash
+# Agent system (local)
 make dev                        # Run local ADK server (localhost:8080)
-# Or directly:
-python -m perception_app.main --host 127.0.0.1 --port 8080
 
-# Verify agent configs
+# Dashboard
+cd dashboard && npm install && npm run dev   # Vite dev server
+
+# Verify agent YAML configs load
 python perception_app/agent_engine_app.py
 ```
 
 ### Testing
 ```bash
 # Run all tests
-make test
-# Or: pytest tests/ -v --cov=perception_app
+make test                       # Note: Makefile uses --cov=app (legacy path)
+pytest tests/ -v --cov=perception_app  # Correct coverage target
 
-# Run specific test suites (as CI does)
+# By test directory (matches CI)
 pytest tests/unit/ -v --no-cov
 pytest tests/api/ -v --no-cov
 pytest tests/mcp/ -v --no-cov
 pytest tests/agent/ -v --no-cov
 pytest tests/security/ -v --no-cov
 
-# Run single test file
+# By marker (defined in pyproject.toml)
+pytest -m unit                  # Fast, no external deps
+pytest -m smoke                 # Quick smoke tests
+pytest -m "not slow"            # Skip slow tests
+pytest -m e2e                   # Playwright browser tests (needs: playwright install)
+
+# Single file
 pytest tests/unit/test_rss_parsing.py -v
 
-# Full production suite (~5,196 tests)
+# Full suite (~5,196 tests)
 ./scripts/run_all_tests.sh
 ```
 
 ### Linting
 ```bash
-make lint                       # Run all linters
+make lint                       # Note: Makefile targets app/ (legacy path)
 make format                     # Auto-format with black
 
-# Individual tools
+# Run against correct paths (both app/ and perception_app/ exist)
 black --check perception_app/
 ruff check perception_app/
 mypy perception_app/
+
+# Dashboard
+cd dashboard && npm run lint
 ```
 
 ### Deployment
@@ -121,94 +152,43 @@ gcloud run deploy perception-mcp \
 # Dashboard
 cd dashboard && npm run build && firebase deploy --only hosting
 
+# Functions
+firebase deploy --only functions
+
 # Terraform
-cd infra/terraform/envs/dev
-tofu init && tofu plan && tofu apply
+cd infra/terraform/envs/dev && tofu init && tofu plan && tofu apply
 ```
-
-### Verify MCP is Alive
-```bash
-curl https://perception-mcp-w53xszfqnq-uc.a.run.app/health
-
-curl -X POST https://perception-mcp-w53xszfqnq-uc.a.run.app/mcp/tools/fetch_rss_feed \
-  -H "Content-Type: application/json" \
-  -d '{"feed_url": "https://news.ycombinator.com/rss", "max_items": 10}'
-```
-
-## Project Structure
-
-```
-perception/
-├── perception_app/
-│   ├── main.py                    # Dev entrypoint (uvicorn)
-│   ├── agent_engine_app.py        # Production entrypoint (Vertex AI)
-│   ├── perception_agent/
-│   │   ├── agents/                # Agent YAML configs (agent_0-8)
-│   │   ├── tools/                 # Python tools per agent (agent_*_tools.py)
-│   │   └── config/
-│   │       └── rss_sources.yaml   # RSS feed sources
-│   ├── jvp_agent/                 # A2A protocol wrapper
-│   │   ├── agent.yaml             # JVP agent config
-│   │   ├── a2a.py                 # A2A protocol implementation
-│   │   └── memory.py              # Context caching
-│   └── mcp_service/
-│       ├── main.py                # FastAPI app
-│       └── routers/               # Tool endpoints (rss.py, storage.py, etc.)
-├── dashboard/                     # React + Vite + TypeScript
-├── infra/terraform/               # OpenTofu IaC
-├── scripts/
-│   ├── dev_run_adk.sh            # Local dev server
-│   ├── deploy_agent_engine.sh    # Deploy to Vertex AI
-│   ├── run_all_tests.sh          # Full test suite
-│   └── run_ingestion_once.py     # Manual ingestion trigger
-├── tests/
-│   ├── unit/                      # Unit tests
-│   ├── api/                       # API tests
-│   ├── mcp/                       # MCP router tests
-│   ├── agent/                     # Agent tests
-│   ├── security/                  # Security tests
-│   └── factories/                 # Test data factories
-└── 000-docs/                      # Technical documentation
-```
-
-## Key Files
-
-- `perception_app/agent_engine_app.py:36` - Agent loading function
-- `perception_app/perception_agent/agents/agent_0_orchestrator.yaml:1` - Root orchestrator config
-- `perception_app/mcp_service/main.py:39` - MCP FastAPI app
-- `.github/workflows/ci.yml` - CI pipeline (lint, test, security, tofu)
 
 ## CI/CD
 
-Push to `main` triggers GitHub Actions:
-1. **lint** - black, ruff, mypy
-2. **test** - pytest (unit, api, mcp, agent, security)
-3. **security** - safety check dependencies
-4. **tofu** - Terraform/OpenTofu validate
+Push to `main` or `develop` triggers `.github/workflows/ci.yml`:
+1. **lint** - black, ruff (both `app/` and `perception_app/` paths)
+2. **test** - pytest by directory (unit, api, mcp, agent, security) using `requirements-test.txt`
+3. **security** - safety check on requirements.txt
+4. **tofu** - OpenTofu init/fmt/validate on `infra/terraform/envs/dev`
 
-Deployment workflows:
-- `.github/workflows/deploy-mcp.yml` - MCP to Cloud Run
-- `.github/workflows/deploy-agent-engine.yml` - Agents to Vertex AI
-- `.github/workflows/deploy-dashboard.yml` - Dashboard to Firebase
+Deployment workflows (separate files):
+- `deploy-mcp.yml` - MCP to Cloud Run
+- `deploy-agent-engine.yml` / `deploy-agents.yml` - Agents to Vertex AI
+- `deploy-dashboard.yml` / `deploy-firebase-dashboard.yml` - Dashboard to Firebase
 
 Uses Workload Identity Federation (WIF) for keyless GCP auth.
 
-## Tech Stack
-
-- **Agents:** Google ADK, Vertex AI Agent Engine, A2A Protocol
-- **AI Model:** Gemini 2.0 Flash
-- **MCP Service:** FastAPI on Cloud Run
-- **Database:** Firestore (us-central1, `perception-db`)
-- **Dashboard:** React 18 + Vite + TypeScript + TailwindCSS
-- **IaC:** OpenTofu (Terraform-compatible)
-- **Observability:** Cloud Logging, OpenTelemetry (partial)
-
 ## Cloud-Only MCP Policy
 
-MCPs run ONLY on Cloud Run. No localhost MCP servers:
-- ✅ Agents: Local development OK (`make dev`)
-- ❌ MCP: Cloud Run only (no local testing)
-- ✅ Tests: Use staging Cloud Run URLs
+MCPs run ONLY on Cloud Run. No localhost MCP servers.
+- Agents: Local development OK (`make dev`)
+- MCP: Cloud Run only — never run locally
+- Tests: Use staging Cloud Run URLs
+- Dashboard auto-ingestion hits the Cloud Run MCP directly
+
+## Codebase Gotchas
+
+- **Dual source paths**: Both `app/` and `perception_app/` exist. The Makefile lint/test targets reference `app/` (legacy), while active code is in `perception_app/`. CI lints both.
+- **`jvp_agent` is top-level**: Not inside `perception_app/`. It's imported directly by `perception_app/main.py`.
+- **Named Firestore database**: `perception-db`, not `(default)`. Must pass this name when initializing Firestore clients.
+- **pytest asyncio**: `asyncio_mode = "auto"` in pyproject.toml — no need for `@pytest.mark.asyncio`.
+- **Line length**: 120 chars (black + ruff both configured to 120).
 
 ## Environment Variables
 
@@ -219,13 +199,10 @@ VERTEX_LOCATION=us-central1
 VERTEX_AGENT_ENGINE_ID=4241324322704064512
 ```
 
+Dashboard uses `VITE_FIREBASE_*` env vars (with hardcoded fallbacks in `dashboard/src/firebase.ts`).
+
 ## Documentation
 
 All docs in `000-docs/` with naming convention: `PREFIX-TYPE-CATEGORY-description.md`
 - `6767-*` = Evergreen (architecture, guides, plans)
 - `0XX-*` = Sequential (AARs, phase reports)
-
-Key docs:
-- `6767-AT-ARCH-observability-and-monitoring.md` - Monitoring guide
-- `6767-OD-GUID-agent-engine-deploy.md` - Deployment guide
-- `6767-PP-PLAN-release-log.md` - Version history

--- a/dashboard/src/components/IngestionButton.tsx
+++ b/dashboard/src/components/IngestionButton.tsx
@@ -145,6 +145,20 @@ export default function IngestionButton() {
     [stopPolling, handleComplete]
   )
 
+  // Listen for auto-ingestion started by useAutoIngestion hook
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const runId = (e as CustomEvent<{ run_id: string }>).detail.run_id
+      if (phase === 'idle' && runId) {
+        setPhase('starting')
+        startTimeRef.current = Date.now()
+        pollStatus(runId)
+      }
+    }
+    window.addEventListener('auto-ingestion-started', handler)
+    return () => window.removeEventListener('auto-ingestion-started', handler)
+  }, [phase, pollStatus])
+
   const handleRunIngestion = async () => {
     setPhase('starting')
     startTimeRef.current = Date.now()

--- a/dashboard/src/hooks/useAutoIngestion.ts
+++ b/dashboard/src/hooks/useAutoIngestion.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+
+const MCP_URL = 'https://perception-mcp-w53xszfqnq-uc.a.run.app'
+const SESSION_KEY = 'perception-auto-ingestion-fired'
+
+export default function useAutoIngestion() {
+  useEffect(() => {
+    if (sessionStorage.getItem(SESSION_KEY)) return
+
+    sessionStorage.setItem(SESSION_KEY, '1')
+
+    fetch(`${MCP_URL}/trigger/ingestion`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        trigger: 'auto',
+        time_window_hours: 24,
+        max_items_per_source: 50,
+      }),
+    })
+      .then(async (res) => {
+        if (res.status === 202) {
+          const data = await res.json()
+          toast.info('Refreshing your feed...', {
+            description: `Run ID: ${data.run_id}`,
+          })
+          window.dispatchEvent(
+            new CustomEvent('auto-ingestion-started', {
+              detail: { run_id: data.run_id },
+            })
+          )
+        }
+        // 409 = already running, silently ignore
+      })
+      .catch(() => {
+        // Fire-and-forget — don't block dashboard load
+      })
+  }, [])
+}

--- a/dashboard/src/pages/Articles.tsx
+++ b/dashboard/src/pages/Articles.tsx
@@ -234,11 +234,13 @@ export default function Articles() {
 
       try {
         const articlesRef = collection(db, 'articles')
+        const cutoff = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
         let q
 
         if (selectedCategory === 'all') {
           q = query(
             articlesRef,
+            where('published_at', '>=', cutoff),
             orderBy('published_at', 'desc'),
             limit(100)
           )
@@ -246,6 +248,7 @@ export default function Articles() {
           q = query(
             articlesRef,
             where('category', '==', selectedCategory),
+            where('published_at', '>=', cutoff),
             orderBy('published_at', 'desc'),
             limit(100)
           )

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import SystemActivityCard from '../components/SystemActivityCard'
 import AuthorsCard from '../components/AuthorsCard'
 import FooterBranding from '../components/FooterBranding'
 import IngestionButton from '../components/IngestionButton'
+import useAutoIngestion from '../hooks/useAutoIngestion'
 
 // Stagger animation variants for cards
 const containerVariants = {
@@ -32,6 +33,8 @@ const itemVariants = {
 }
 
 export default function Dashboard() {
+  useAutoIngestion()
+
   return (
     <motion.div
       initial="hidden"

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -25,7 +25,7 @@ export default function Login() {
       } else {
         await signInWithEmailAndPassword(auth, email, password)
       }
-      navigate('/')
+      navigate('/dashboard')
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Authentication failed'
       toast.error('Authentication Failed', { description: message })

--- a/perception_app/mcp_service/routers/rss.py
+++ b/perception_app/mcp_service/routers/rss.py
@@ -128,8 +128,9 @@ def is_within_time_window(published_at: str, time_window_hours: int) -> bool:
         article_time = datetime.fromisoformat(published_at.replace('Z', '+00:00'))
         cutoff_time = datetime.now(tz=timezone.utc) - timedelta(hours=time_window_hours)
         return article_time >= cutoff_time
-    except Exception:
-        return True  # Include if we can't parse date
+    except Exception as e:
+        logger.warning(f"is_within_time_window: failed to parse '{published_at}': {e}")
+        return False  # Exclude if we can't parse date
 
 
 # Tool Endpoint

--- a/tests/unit/test_rss_parsing.py
+++ b/tests/unit/test_rss_parsing.py
@@ -207,13 +207,13 @@ class TestIsWithinTimeWindow:
 
         assert result is True  # Within window
 
-    def test_malformed_date_returns_true(self):
-        """Test malformed date returns True (inclusive)."""
+    def test_malformed_date_returns_false(self):
+        """Test malformed date returns False (exclude unparseable articles)."""
         from perception_app.mcp_service.routers.rss import is_within_time_window
 
         result = is_within_time_window("not-a-date", 24)
 
-        assert result is True
+        assert result is False
 
     def test_with_z_suffix(self):
         """Test date with Z timezone suffix."""


### PR DESCRIPTION
## Summary

- **Login redirects to `/dashboard`** instead of `/` (Articles feed) so users land on the command center
- **Auto-ingestion on dashboard mount** — fires `POST /trigger/ingestion` once per browser session (sessionStorage guard), so the feed stays fresh without manual clicks
- **IngestionButton picks up auto-triggered runs** via `auto-ingestion-started` custom event, showing real-time progress
- **Articles feed filters to last 48 hours** — `where("published_at", ">=", cutoff)` on both the "all" and per-category queries
- **Backend `is_within_time_window()` returns `False` on date parse failure** instead of `True` (defense-in-depth; the exception path is unreachable in practice since `normalize_published_date()` falls back to `datetime.now()`)

## Files Changed

| File | Change |
|------|--------|
| `dashboard/src/pages/Login.tsx` | `navigate("/")` → `navigate("/dashboard")` |
| `dashboard/src/hooks/useAutoIngestion.ts` | **New** — fire-and-forget ingestion trigger with sessionStorage dedup |
| `dashboard/src/pages/Dashboard.tsx` | Call `useAutoIngestion()` hook |
| `dashboard/src/components/IngestionButton.tsx` | Listen for `auto-ingestion-started` event |
| `dashboard/src/pages/Articles.tsx` | Add 48h `published_at` range filter to Firestore queries |
| `perception_app/mcp_service/routers/rss.py` | Fix `is_within_time_window()` to reject unparseable dates |

## Test plan

- [x] `npx tsc --noEmit` — compiles clean
- [x] `npx vite build` — production build succeeds
- [x] `pytest tests/mcp/ -v --no-cov` — 39/39 passed
- [ ] Manual: login → lands on `/dashboard`, ingestion auto-starts
- [ ] Manual: navigate to Feed → no old articles, only last 48h
- [ ] Manual: IngestionButton shows progress for auto-triggered run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic ingestion trigger on dashboard load with a session-level kickoff, user notification including run ID, and live status polling

* **Improvements**
  * Articles list limited to items published in the last 48 hours
  * Post-login now redirects to the dashboard

* **Bug Fixes**
  * Articles with unparseable timestamps are now excluded

* **Documentation**
  * Project docs updated with architecture, setup, and deployment details

* **Tests**
  * Timestamp parsing tests updated to reflect exclusion of malformed dates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->